### PR TITLE
Update ukf.py

### DIFF
--- a/scripts/ukf.py
+++ b/scripts/ukf.py
@@ -15,7 +15,7 @@ logging.basicConfig(level=logging.DEBUG, format=logfmt(__file__))
 # default UKFTractography parameters
 ukfdefaults = ['--numTensor', 2, '--stoppingFA', 0.15, '--seedingThreshold', 0.18, '--Qm', 0.001, '--Ql', 70,
                '--Rs', 0.015, '--stepLength', 0.3, '--recordLength', 1.7, '--stoppingThreshold', 0.1,
-               '--seedsPerVoxel', 10, '--recordTensors']
+               '--seedsPerVoxel', 10, '--recordTensors', '--numThreads', '8']
 
 
 class App(cli.Application):


### PR DESCRIPTION
updating ukfdefault call to use the numThreads flag to set the default to 8 threads.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Update the UKFTractography default parameters to include a default setting of 8 threads for the numThreads flag.

Enhancements:
- Set the default number of threads to 8 in the UKFTractography parameters.

<!-- Generated by sourcery-ai[bot]: end summary -->